### PR TITLE
Privacy URL isnt actually used anywhere, removing it from localizatio…

### DIFF
--- a/app/locales/en/branding.json
+++ b/app/locales/en/branding.json
@@ -2,6 +2,5 @@
     "branding.product.login.title" : "OpenStack",
     "branding.pageTitle.title" : "OpenStack Operations Console",
     "branding.masthead.title": "Ops Console",
-    "footer.privacy.url": "https://www.privacypolicyurlhere.com/policy.html",
     "footer.copyright": "Company ProductName - Copyright YEAR. All rights reserved."
 }

--- a/app/locales/en/common.json
+++ b/app/locales/en/common.json
@@ -266,7 +266,6 @@
     "login.password.placeholder" : "Enter Your Password",
 
     "footer.terms": "Terms of Use",
-    "footer.privacy": "Privacy Policy",
 
     "common.confirm.deletion": "Confirm Deletion",
     "common.delete.confirm.line2": "This cannot be undone. Select \"CONFIRM\" to continue...",

--- a/app/locales/ja/branding.json
+++ b/app/locales/ja/branding.json
@@ -2,6 +2,5 @@
     "branding.product.login.title" : "OpenStack",
     "branding.pageTitle.title" : "OpenStack Operations Console",
     "branding.masthead.title": "Ops Console",
-    "footer.privacy.url": "https://www.privacypolicyurlhere.com/policy.html",
     "footer.copyright": "Company ProductName - Copyright YEAR. All rights reserved."
 }

--- a/app/locales/ja/common.json
+++ b/app/locales/ja/common.json
@@ -236,7 +236,6 @@
   "login.user.placeholder": "アカウントを入力",
   "login.password.placeholder": "パスワードを入力",
   "footer.terms": "使用条件",
-  "footer.privacy": "プライバシーポリシー",
   "common.confirm.deletion": "削除の確認",
   "common.delete.confirm.line2": "これは取り消せません。続行するには [確認] を選択します...",
   "common.confirm.line2": "続行するには [確認] を選択してください...",

--- a/app/locales/zh/branding.json
+++ b/app/locales/zh/branding.json
@@ -2,6 +2,5 @@
     "branding.product.login.title" : "OpenStack",
     "branding.pageTitle.title" : "OpenStack Operations Console",
     "branding.masthead.title": "Ops Console",
-    "footer.privacy.url": "https://www.privacypolicyurlhere.com/policy.html",
     "footer.copyright": "Company ProductName - Copyright YEAR. All rights reserved."
 }

--- a/app/locales/zh/common.json
+++ b/app/locales/zh/common.json
@@ -236,7 +236,6 @@
   "login.user.placeholder": "输入您的帐户",
   "login.password.placeholder": "输入您的密码",
   "footer.terms": "使用条款",
-  "footer.privacy": "隐私策略",
   "common.confirm.deletion": "确认删除",
   "common.delete.confirm.line2": "此操作无法撤消。请选择“确认”以继续...",
   "common.confirm.line2": "请选择“确认”以继续...",


### PR DESCRIPTION
…n bundles

We checked and the privacy keys aren't actually in any of the code (looked back 2 versions as well, same result)... Decided to go ahead and remove them to avoid confusion